### PR TITLE
Adding options for custom config files paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,20 @@ You'll probably want to add a `test` script to your package.json `scripts` with 
 ```
 
 ## CLI
-node-jspm-jasmine exposes a cli that is accessible through the `jspmjasmine` command. Right now, the cli takes in no arguments, since all configuration is handled inside of the `spec/support/jasmine.json` file. All [jasmine configuration options](http://jasmine.github.io/2.4/node.html#section-Configuration) will be respected, with all `helpers` and `spec_files` being loaded via JSPM instead of node's `require` function.
+node-jspm-jasmine exposes a cli that is accessible through the `jspmjasmine` command. All [jasmine configuration options](http://jasmine.github.io/2.4/node.html#section-Configuration) will be respected, with all `helpers` and `spec_files` being loaded via JSPM instead of node's `require` function.
 
 * Note: node-jspm-jasmine will expose the `System` object to the `global`, for convenience.
-* Another note: right now the CLI doesn't have any options, flags, targets, etc. You just run `jspmjasmine` with nothing else.
+
+##### Options:
+Custom path to jasmine.json config file:
+
+`jspmjasmine --jasmine-config "PATH/TO/JASMINE/JSON/RELATIVE/TO/CWD/"`
+* Note: `jasmine-config` defaults to path where `jspmjasmine` is being executed + `/spec/support/jasmine.json`.
+
+Custom path to package.json config file:
+
+`jspmjasmine --package-path "PATH/TO/PACKAGE/JSON/RELATIVE/TO/CWD/"`
+* Note: `package-path` defaults to path where `jspmjasmine` is being executed.
 
 ## JS API
 node-jspm-jasmine exports named exports which are to be used as a js library. Example:
@@ -36,7 +46,34 @@ nodeJspmJasmine.runTests({});
 ```
 
 #### runTests(opts)
-This will run your jasmine tests, loading all the tests with JSPM instead of node's `require`. Right now, `opts` is just a placeholder and there aren't really any options you can pass in.
+This will run your jasmine tests, loading all the tests with JSPM instead of node's `require`.
+
+##### Options:
+```js
+runTests({
+    // Provide a custom path to jasmine.json config file.
+    // Defaults to path where the script is being
+    // executed + '/spec/support/jasmine.json'.
+    jasmineConfig: "PATH/TO/JASMINE/JSON/RELATIVE/TO/CWD/",
+
+    // Provide a custom path to package.json config file.
+    // Defaults to path where the script is being executed.
+    packagePath: "PATH/TO/PACKAGE/JSON/RELATIVE/TO/CWD/"
+})
+```
+
+Alternatively, you can pass the jasmine config object directly.
+```js
+runTests({
+    // Provide a custom jasmine configuration without a jasmine.json.
+    jasmineConfig: {
+        "spec_dir": "src/test/specs",
+        "spec_files": ["**/*.js"],
+        "helpers": []
+    },
+    packagePath: "PATH/TO/PACKAGE/JSON/RELATIVE/TO/CWD/"
+})
+```
 
 ## Ignoring / mocking specific imports
 What you're about to read is nothing specific to node-jspm-jasmine, but I figured writing it down might save someone from sifting through hard-to-find docs for Jasmine and JSPM/SystemJS/es6-module-loader. In order to mock or ignore files, you should create a [jasmine helper file](http://jasmine.github.io/2.4/node.html#section-12) so that the mocking/ignoring is done before the tests are run. These files by default go into your `spec/helpers` directory, but that can be controlled in the jasmine.json file (note that the file patterns that you put into the `helpers` array will be relative to the `spec` directory itself, not the package's root directory nor the `spec/helpers` directory). Once you've got a helper file, use [System.registerDynamic](https://github.com/systemjs/systemjs/blob/master/docs/system-api.md#systemregisterdynamicname--deps-executingrequire-declare) to do one of the following:

--- a/bin/jspmjasmine.js
+++ b/bin/jspmjasmine.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../lib/cli.js');
+require('../lib/cli.js').run( process.argv );

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "glob": "^7.0.3"
+    "glob": "^7.0.3",
+    "commander": "^2.9.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,20 @@
 import * as jsApi from './node-jspm-jasmine.js';
+import commander from 'commander';
 
-jsApi.runTests({}, function(err) {
-	console.error(err);
-	process.exit(1);
-});
+export function run(args) {
+
+    commander
+        .option('-c, --jasmine-config <path>')
+        .option('-c, --package-path <path>')
+        .parse(process.argv)
+
+    let config = {
+        jasmineConfig: commander.jasmineConfig,
+        packagePath: commander.packagePath
+    }
+
+    jsApi.runTests(config, function(err) {
+        console.error(err);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
First off, awesome job on this project, it's exactly what I was looking for. 

As for the pull request... I'm sure you intend to provide the ability to provide custom options at some point, so I figured I would get the ball rolling with two critical options that I need in order to use this project. I've added a reasonable implementation for providing custom paths to the package.json and jasmine.json config files, both for the CLI and JS API, and made some other modifications as depicted in my commits. Let me know what you think and if you want me to change anything.
