### PR TITLE
Fix the custom config to work more semantically

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ node-jspm-jasmine exposes a cli that is accessible through the `jspmjasmine` com
 ##### Options:
 Custom path to jasmine.json config file:
 
-`jspmjasmine --jasmine-config "PATH/TO/JASMINE/JSON/RELATIVE/TO/CWD/"`
+`jspmjasmine --jasmine-config
+"PATH/TO/JASMINE/JSON/RELATIVE/TO/CWD/config.json"`
 * Note: `jasmine-config` defaults to path where `jspmjasmine` is being executed + `/spec/support/jasmine.json`.
 
 Custom path to package.json config file:

--- a/src/node-jspm-jasmine.js
+++ b/src/node-jspm-jasmine.js
@@ -38,19 +38,8 @@ export function runTests(opts, errCallback = function() {}) {
 
 	try {
 
-		const jasmineConfig =
-			( typeof opts.jasmineConfig === 'object' ?
-				opts.jasmineConfig :
-				require(
-					path.join(
-						( typeof opts.jasmineConfig === 'string' ?
-							opts.jasmineConfig :
-							process.cwd() + '/spec/support'
-						),
-						'jasmine.json'
-					)
-				)
-			);
+		const jasmineConfig = getJasmineConfig(opts.jasmineConfig)
+
 		const specDir = jasmineConfig.spec_dir;
 		const specFiles = jasmineConfig.spec_files;
 		delete jasmineConfig.spec_files;
@@ -114,4 +103,17 @@ function importTestFiles(SystemJS, jasmine, specDir, specFiles, errCallback) {
 			});
 		});
 	}
+}
+
+function getJasmineConfig(config) {
+	if (typeof config === 'object') {
+		return config;
+	}
+
+	if (typeof config === 'string') {
+		return require(path.join(process.cwd(), config));
+	}
+
+	// Default location is provided by "jasmine init"
+	return require(path.join(process.cwd() + '/spec/support', 'jasmine.json'));
 }


### PR DESCRIPTION
For example the following now works:
`jspmjasmine --jasmine-config jasmine.json`

where `jasmine.json` is relative to the current working directory
