### PR TITLE
Set default error callback for runTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,11 @@ nodeJspmJasmine.
 ```
 
 #### runTests(opts, errBack)
-This will run your jasmine tests, loading all the tests with JSPM instead of node's `require`. The second argument `errBack` is a function that is called when the tests either succeed or fail. If the tests succeed, `errBack` will be called with a `null` first argument. If they fail, `errBack` will be called with a reason why the tests failed.
-
-Errback usage:
-```js
-runTests(opts, function(err) {
-  if (err) {
-    console.error(err);
-  } else {
-    console.log("tests passed");
-  }
-}
-```
+This will run your jasmine tests, loading all the tests with JSPM instead of node's `require`. 
 
 ##### Options:
+The first arguments are options that you would pass to jspm-jasmine similar to the CLI.
+
 ```js
 runTests({
 
@@ -176,6 +167,21 @@ runTests({
   watchFiles: ["src/**/*.js", "another-glob*.js"],
 })
 ```
+
+##### Error Callback *(optional)*:
+The second argument `errBack` is a function that is called when the tests either succeed or fail. If the tests succeed, `errBack` will be called with a `null` first argument. If they fail, `errBack` will be called with a reason why the tests failed. 
+
+```js
+runTests(opts, function(err) {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log("tests passed");
+  }
+}
+```
+
+jspm-jasmine already provides a default `errBack` function which is adequate under most circumstances. You need to provide an `errback` only if you wish to modify the default logging behaviour.
 
 ## mockModules
 In order to mock or ignore files, you'll need to call the `mockModules` function which is defined on the global by

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,5 @@
 import * as jsApi from './node-jspm-jasmine.js';
 import commander from 'commander';
-import exit from 'exit';
-import chalk from 'chalk';
-
-import { isWatching } from './watcher.js';
 
 export function run(args) {
 
@@ -40,22 +36,7 @@ export function run(args) {
 		config.coverage.cleanDir = commander.cleanCoverageDir;
 	}
 
-	jsApi.runTests(config, function(err, safeExit, optionalMessage) {
-		if (err) {
-			console.log(chalk.red(err && err.stack ? err.stack : err));
-		}
-		if (optionalMessage) {
-			console.log('');
-			console.log(chalk.inverse(optionalMessage));
-		}
-		if (!isWatching()) {
-			if (safeExit) {
-				safeExit();
-			} else {
-				exit(1);
-			}
-		}
-	});
+	jsApi.runTests(config);
 }
 
 function collect(val, list) {

--- a/src/node-jspm-jasmine.js
+++ b/src/node-jspm-jasmine.js
@@ -414,10 +414,11 @@ function finishTestRun(passed, jasmine, errCallback) {
 		const exitCode = passed ? 0 : 2;
 
 		const successResult = null;
-		errCallback(successResult);
-
+		
 		// this is the exit strategy inside Jasmine, it takes care
 		// of cross platform exit bugs
-		jasmine.exit(exitCode, process.platform, process.version, process.exit, jasmine.exit);
+		const safeExit = () => jasmine.exit(exitCode, process.platform, process.version, process.exit, jasmine.exit);
+
+		errCallback(successResult, safeExit);
 	}
 }

--- a/src/node-jspm-jasmine.js
+++ b/src/node-jspm-jasmine.js
@@ -10,12 +10,30 @@ import { remap } from "remap-istanbul";
 import inlineSourceMap from "inline-source-map-comment";
 import chalk from 'chalk';
 import mkdirp from 'mkdirp';
+import exit from 'exit';
 
 import Timer from './timer.js';
 import * as Mocker from './mocker.js';
 import { isWatching, initWatcher, watchFile, finishedTestRun as notifyWatcherFinishedTestRun } from './watcher.js';
 
-export function runTests(opts, errCallback = function() {}) {
+function errorCallbackDefault(err, safeExit, optionalMessage) {
+	if (err) {
+		console.log(chalk.red(err && err.stack ? err.stack : err));
+	}
+	if (optionalMessage) {
+		console.log('');
+		console.log(chalk.inverse(optionalMessage));
+	}
+	if (!isWatching()) {
+		if (safeExit) {
+			safeExit();
+		} else {
+			exit(1);
+		}
+	}
+}
+
+export function runTests(opts, errCallback = errorCallbackDefault) {
 	opts.watchFiles = opts.watchFiles || [];
 	initWatcher(!!opts.watch || opts.watchFiles.length > 0, opts, errCallback);
 


### PR DESCRIPTION
As discussed in #43, moved errCallback from cli.js to node-jspm-jasmine.js and set it up as default for runTests().

